### PR TITLE
issue #5 - won't run on android 5.0.1 nexus 7 or on android 5.1 nexus 6

### DIFF
--- a/Android Studio Project/app/src/main/java/com/theksmith/android/car_bus_interface/CBIServiceMain.java
+++ b/Android Studio Project/app/src/main/java/com/theksmith/android/car_bus_interface/CBIServiceMain.java
@@ -70,7 +70,7 @@ public class CBIServiceMain extends Service {
     private static final int PERSISTENT_NOTIFICATION_ID = 0;
 
     private NotificationManager mNoticeManager;
-    private final Notification.Builder mNoticeBuilder;
+    private Notification.Builder mNoticeBuilder;
 
     private String mNoticeStatus;
     private String mNoticeError;
@@ -106,14 +106,14 @@ public class CBIServiceMain extends Service {
     public CBIServiceMain() {
         if (D) Log.d(TAG, "CBIServiceMain()");
 
-        mNoticeBuilder = new Notification.Builder(this);
-
         mBTAdapter = BluetoothAdapter.getDefaultAdapter();
     }
 
     @Override
     public void onCreate() {
         super.onCreate();
+        
+        mNoticeBuilder = new Notification.Builder(this);
 
         if (D) Log.d(TAG, "onCreate()");
 


### PR DESCRIPTION
I want to resolve issue #5 
Notification.Builder is created in the constructor of CBIServiceMain,
but CBIServiceMain passes an instance of itself inside the constructor.
Objects are not guaranteed to be fully constructed until after the
constructor returns.
Moving the construction of NotificationBuilder to the onCreate method